### PR TITLE
[FEAT] SpringAI 퀴즈 생성 및 저장 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+}
+
+ext {
+	set('springAiVersion', "1.0.0-M4")
 }
 
 dependencies {
@@ -29,6 +34,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation "org.springframework.ai:spring-ai-openai-spring-boot-starter:${springAiVersion}"
+	implementation "org.springframework.ai:spring-ai-core:${springAiVersion}"
+	implementation 'org.apache.pdfbox:pdfbox:2.0.29'
+	implementation 'org.apache.pdfbox:pdfbox-tools:2.0.29'
+
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -43,7 +55,11 @@ dependencies {
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
-
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+	}
+}
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/src/main/java/PlanQ/PlanQ/DashBoard/DTO/DailyQuizDto.java
+++ b/src/main/java/PlanQ/PlanQ/DashBoard/DTO/DailyQuizDto.java
@@ -6,13 +6,22 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 @ToString
-@AllArgsConstructor
+//@AllArgsConstructor
 @Builder
 public class DailyQuizDto {
 
     private String category;
-    private String quizTitle;
-    private int questionNum;
+    private String title;
+    private int questionCnt;
     private boolean isSolved;
     private Color color;
+
+    // IntelliJ에서 JPQL과 DTO 매핑 시 이를 인식하지 못하는 경우가 있어 명시적으로 작성했습니다.
+    public DailyQuizDto(String category, String title, int questionCnt, boolean isSolved, Color color) {
+        this.category = category;
+        this.title = title;
+        this.questionCnt = questionCnt;
+        this.isSolved = isSolved;
+        this.color = color;
+    }
 }

--- a/src/main/java/PlanQ/PlanQ/DashBoard/DTO/IncorrectQuestionDto.java
+++ b/src/main/java/PlanQ/PlanQ/DashBoard/DTO/IncorrectQuestionDto.java
@@ -6,12 +6,20 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 @ToString
-@AllArgsConstructor
+//@AllArgsConstructor
 @Builder
 public class IncorrectQuestionDto {
 
     private Color color;
-    private String quizTitle;
-    private int num;
-    private String questionTitle;
+    private String title;
+    private int question_num;
+    private String content;
+
+    // IntelliJ에서 JPQL과 DTO 매핑 시 이를 인식하지 못하는 경우가 있어 명시적으로 작성했습니다.
+    public IncorrectQuestionDto(Color color, String title, int question_num, String content) {
+        this.color = color;
+        this.title = title;
+        this.question_num = question_num;
+        this.content = content;
+    }
 }

--- a/src/main/java/PlanQ/PlanQ/DashBoard/DTO/SubmitReportDto.java
+++ b/src/main/java/PlanQ/PlanQ/DashBoard/DTO/SubmitReportDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 @ToString
-@AllArgsConstructor
+//@AllArgsConstructor
 @Builder
 public class SubmitReportDto {
 
@@ -16,5 +16,13 @@ public class SubmitReportDto {
     private LocalDateTime date;
     private String comment;
     private Color color;
+
+    // IntelliJ에서 JPQL과 DTO 매핑 시 이를 인식하지 못하는 경우가 있어 명시적으로 작성했습니다.
+    public SubmitReportDto(String reportTitle, LocalDateTime date, String comment, Color color) {
+        this.reportTitle = reportTitle;
+        this.date = date;
+        this.comment = comment;
+        this.color = color;
+    }
 
 }

--- a/src/main/java/PlanQ/PlanQ/DashBoard/DTO/WeeklyQuizDto.java
+++ b/src/main/java/PlanQ/PlanQ/DashBoard/DTO/WeeklyQuizDto.java
@@ -5,12 +5,18 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 @ToString
-@AllArgsConstructor
+//@AllArgsConstructor
 @Builder
 public class WeeklyQuizDto {
 
-    private int totalNum;
-    private int correctNum;
+    private int questionCnt;
+    private int correctCnt;
     private int incorrectNum;
 
+    // IntelliJ에서 JPQL과 DTO 매핑 시 이를 인식하지 못하는 경우가 있어 명시적으로 작성했습니다.
+    public WeeklyQuizDto(int questionCnt, int correctCnt, int incorrectNum) {
+        this.questionCnt = questionCnt;
+        this.correctCnt = correctCnt;
+        this.incorrectNum = incorrectNum;
+    }
 }

--- a/src/main/java/PlanQ/PlanQ/DashBoard/Repository/DailyQuizRepository.java
+++ b/src/main/java/PlanQ/PlanQ/DashBoard/Repository/DailyQuizRepository.java
@@ -1,8 +1,6 @@
 package PlanQ.PlanQ.DashBoard.Repository;
 
 import PlanQ.PlanQ.DashBoard.DTO.DailyQuizDto;
-import PlanQ.PlanQ.DashBoard.DTO.IncorrectQuestionDto;
-import PlanQ.PlanQ.DashBoard.DTO.WeeklyQuizDto;
 import PlanQ.PlanQ.quiz.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,8 +10,8 @@ import java.util.List;
 
 @Repository
 public interface DailyQuizRepository extends JpaRepository<Quiz,Long> {
-    @Query("select new PlanQ.PlanQ.DashBoard.DTO.DailyQuizDto(q.category,q.title,q.questionNum,q.isSolved,q.color) " +
+    @Query("select new PlanQ.PlanQ.DashBoard.DTO.DailyQuizDto(q.category,q.title,q.questionCnt,q.isSolved,q.color) " +
             "from Quiz q " +
-            "where q.date = :date")
+            "where q.reviewDate = :date")
     List<DailyQuizDto> findDailyQuizDtosByDate(String date);
 }

--- a/src/main/java/PlanQ/PlanQ/DashBoard/Repository/IncorrectQuizRepository.java
+++ b/src/main/java/PlanQ/PlanQ/DashBoard/Repository/IncorrectQuizRepository.java
@@ -11,9 +11,9 @@ import java.util.List;
 @Repository
 public interface IncorrectQuizRepository extends JpaRepository<Quiz,Long> {
 
-    @Query("select new PlanQ.PlanQ.DashBoard.DTO.IncorrectQuestionDto(qu.color, qu.title, q.num, q.title) " +
+    @Query("select new PlanQ.PlanQ.DashBoard.DTO.IncorrectQuestionDto(qu.color, qu.title, q.question_num, q.content) " +
             "from Question q " +
             "join Quiz qu on qu.id = q.quiz.id " +
-            "where qu.date between :startDate and :endDate")
+            "where qu.reviewDate between :startDate and :endDate")
     List<IncorrectQuestionDto> findIncorrectQuestionDtosByDate(String startDate, String endDate);
 }

--- a/src/main/java/PlanQ/PlanQ/DashBoard/Repository/IncorrectQuizRepository.java
+++ b/src/main/java/PlanQ/PlanQ/DashBoard/Repository/IncorrectQuizRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Repository
 public interface IncorrectQuizRepository extends JpaRepository<Quiz,Long> {
 
-    @Query("select new PlanQ.PlanQ.DashBoard.DTO.IncorrectQuestionDto(qu.color, qu.title, q.question_num, q.content) " +
+    @Query("select new PlanQ.PlanQ.DashBoard.DTO.IncorrectQuestionDto(qu.color, qu.title, q.questionNum, q.content) " +
             "from Question q " +
             "join Quiz qu on qu.id = q.quiz.id " +
             "where qu.reviewDate between :startDate and :endDate")

--- a/src/main/java/PlanQ/PlanQ/DashBoard/Repository/WeeklyQuizRepository.java
+++ b/src/main/java/PlanQ/PlanQ/DashBoard/Repository/WeeklyQuizRepository.java
@@ -12,8 +12,8 @@ import java.util.List;
 @Repository
 public interface WeeklyQuizRepository extends JpaRepository<Quiz,Long> {
 
-        @Query("select new PlanQ.PlanQ.DashBoard.DTO.WeeklyQuizDto(q.questionNum,q.correctNum,q.questionNum-q.correctNum) " +
+        @Query("select new PlanQ.PlanQ.DashBoard.DTO.WeeklyQuizDto(q.questionCnt,q.correctCnt,q.questionCnt-q.correctCnt) " +
             "from Quiz q " +
-            "where q.date between :startDate and :endDate")
+            "where q.reviewDate between :startDate and :endDate")
         List<WeeklyQuizDto> findQuestionNumAndCorrectNumByDate(String startDate, String endDate);
 }

--- a/src/main/java/PlanQ/PlanQ/option/Option.java
+++ b/src/main/java/PlanQ/PlanQ/option/Option.java
@@ -1,24 +1,37 @@
 package PlanQ.PlanQ.option;
 
 import PlanQ.PlanQ.question.Question;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @Entity
 @Table(name = "option")
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Option {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "option_id")
     private Long Id;
 
+    private String content;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     private Question question;
-
-    private String content;
 }

--- a/src/main/java/PlanQ/PlanQ/option/Option.java
+++ b/src/main/java/PlanQ/PlanQ/option/Option.java
@@ -26,12 +26,13 @@ public class Option {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "option_id")
+    @Column(name = "option_id", nullable = false)
     private Long Id;
 
+    @Column(nullable = false)
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
+    @JoinColumn(name = "question_id", nullable = false)
     private Question question;
 }

--- a/src/main/java/PlanQ/PlanQ/option/OptionRepository.java
+++ b/src/main/java/PlanQ/PlanQ/option/OptionRepository.java
@@ -1,0 +1,9 @@
+package PlanQ.PlanQ.option;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OptionRepository extends JpaRepository<Option, Long> {
+
+}

--- a/src/main/java/PlanQ/PlanQ/question/Question.java
+++ b/src/main/java/PlanQ/PlanQ/question/Question.java
@@ -31,25 +31,30 @@ public class Question {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "question_id")
+    @Column(name = "question_id", nullable = false)
     private Long id;
 
     @Column(nullable = false)
-    private int question_num; // num -> question_num
+    private Integer questionNum; // num -> question_num
 
+    @Column(nullable = false)
     private String content; // title -> content
 
+    @Column(nullable = false)
     private String correct;
 
-    private int selectOption; // (long -> int)
+    private Integer selectOption; // (long -> Integer(null 허용을 위해)
 
-    private boolean isCorrect;
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean isCorrect = false;
 
     @Enumerated(EnumType.STRING)
     @Builder.Default
+    @Column(nullable = false)
     private QuestionType questionType = QuestionType.MCQ;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "quiz_id")
+    @JoinColumn(name = "quiz_id", nullable = false)
     private Quiz quiz;
 }

--- a/src/main/java/PlanQ/PlanQ/question/Question.java
+++ b/src/main/java/PlanQ/PlanQ/question/Question.java
@@ -1,42 +1,55 @@
 package PlanQ.PlanQ.question;
 
-import PlanQ.PlanQ.option.Option;
 import PlanQ.PlanQ.quiz.Quiz;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
+import lombok.Setter;
 
 @Data
 @Entity
+@Setter
+@Builder
 @Table(name = "question")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "question_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "quiz_id")
-    private Quiz quiz;
+    @Column(nullable = false)
+    private int question_num; // num -> question_num
 
-    private String title;
-
-    @Enumerated(EnumType.STRING)
-    private QuestionCategory questionCategory;
+    private String content; // title -> content
 
     private String correct;
 
-    @Column(name = "is_correct")
+    private int selectOption; // (long -> int)
+
     private boolean isCorrect;
 
-    @Column(nullable = false)
-    private Long selectOption;
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private QuestionType questionType = QuestionType.MCQ;
 
-    @Column(nullable = false)
-    private int num;
-
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "quiz_id")
+    private Quiz quiz;
 }

--- a/src/main/java/PlanQ/PlanQ/question/QuestionRepository.java
+++ b/src/main/java/PlanQ/PlanQ/question/QuestionRepository.java
@@ -1,0 +1,9 @@
+package PlanQ.PlanQ.question;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+}

--- a/src/main/java/PlanQ/PlanQ/question/QuestionType.java
+++ b/src/main/java/PlanQ/PlanQ/question/QuestionType.java
@@ -1,5 +1,5 @@
 package PlanQ.PlanQ.question;
 
-public enum QuestionCategory {
+public enum QuestionType {
     OX, MCQ // ox선택, 사지선다
 }

--- a/src/main/java/PlanQ/PlanQ/quiz/Quiz.java
+++ b/src/main/java/PlanQ/PlanQ/quiz/Quiz.java
@@ -1,48 +1,61 @@
 package PlanQ.PlanQ.quiz;
 
 import PlanQ.PlanQ.global.Color;
-import PlanQ.PlanQ.question.Question;
 import PlanQ.PlanQ.report.Report;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Data
 @Entity
+@Builder
 @Table(name = "quiz")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Quiz {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "quiz_id")
     private Long id;
 
+    private String title;
+
+    private LocalDateTime reviewDate; // date -> reviewDate
+
+    private LocalTime solveTime; // time -> solveTime
+
+    private String category; // 디자인 회의 필요(직접 지정 or to do 제목)
+
+    private int correctCnt; // correctNum -> correctCnt
+
+    private int questionCnt; // questionNum -> questionCnt
+
+    @Builder.Default
+    private boolean isSolved = false;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean favorite = false;
+
+    @Enumerated(EnumType.STRING)
+    private Color color;
+
     @OneToOne
     @JoinColumn(name = "report_id")
     private Report report;
-
-    private String title;
-
-    private String category;
-
-    private LocalDateTime date;
-
-    @Column(name = "is_solved")
-    private boolean isSolved;
-
-    private LocalDateTime time;
-
-    @Column(name = "correct_num")
-    private int correctNum;
-
-    @Column(name = "question_num")
-    private int questionNum;
-
-    private boolean favorite;
-
-    private Color color;
 }

--- a/src/main/java/PlanQ/PlanQ/quiz/Quiz.java
+++ b/src/main/java/PlanQ/PlanQ/quiz/Quiz.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -19,6 +20,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.mapping.ToOne;
 
 @Data
 @Entity
@@ -30,22 +32,26 @@ public class Quiz {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "quiz_id")
+    @Column(name = "quiz_id", nullable = false)
     private Long id;
 
+    @Column(nullable = false)
     private String title;
 
+    @Column(nullable = false)
     private LocalDateTime reviewDate; // date -> reviewDate
 
     private LocalTime solveTime; // time -> solveTime
 
     private String category; // 디자인 회의 필요(직접 지정 or to do 제목)
 
-    private int correctCnt; // correctNum -> correctCnt
+    private Integer correctCnt; // correctNum -> correctCnt
 
-    private int questionCnt; // questionNum -> questionCnt
+    @Column(nullable = false)
+    private Integer questionCnt; // questionNum -> questionCnt
 
     @Builder.Default
+    @Column(nullable = false)
     private boolean isSolved = false;
 
     @Builder.Default
@@ -55,7 +61,7 @@ public class Quiz {
     @Enumerated(EnumType.STRING)
     private Color color;
 
-    @OneToOne
-    @JoinColumn(name = "report_id")
+    @ManyToOne
+    @JoinColumn(name = "report_id", nullable = false)
     private Report report;
 }

--- a/src/main/java/PlanQ/PlanQ/quiz/QuizRepository.java
+++ b/src/main/java/PlanQ/PlanQ/quiz/QuizRepository.java
@@ -1,0 +1,7 @@
+package PlanQ.PlanQ.quiz;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+
+}

--- a/src/main/java/PlanQ/PlanQ/quiz/QuizService.java
+++ b/src/main/java/PlanQ/PlanQ/quiz/QuizService.java
@@ -1,0 +1,174 @@
+package PlanQ.PlanQ.quiz;
+
+import PlanQ.PlanQ.option.Option;
+import PlanQ.PlanQ.option.OptionRepository;
+import PlanQ.PlanQ.question.Question;
+import PlanQ.PlanQ.question.QuestionRepository;
+import PlanQ.PlanQ.report.Report;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.imageio.ImageIO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.model.Media;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MimeType;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+
+    private final OpenAiChatModel openAiChatModel;
+    private final QuizRepository quizRepository;
+    private final QuestionRepository questionRepository;
+    private final OptionRepository optionRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${quiz.generation.prompt}")
+    private String prompt;
+
+    @Transactional
+    public void generateQuizFromPdf(MultipartFile file, Report report) throws IOException {
+
+        List<BufferedImage> images = convertPdfToImages(file);
+
+        List<Media> mediaList = new ArrayList<>();
+        for (BufferedImage image : images) {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            ImageIO.write(image, "jpeg", outputStream);
+
+            Media media = new Media(
+                MimeType.valueOf(MediaType.IMAGE_JPEG_VALUE),
+                new InputStreamResource(new ByteArrayInputStream(outputStream.toByteArray()))
+            );
+
+            mediaList.add(media);
+        }
+
+        UserMessage userMessage = new UserMessage(prompt, mediaList);
+        String aiResponse = openAiChatModel.call(userMessage);
+
+//        log.info("AI 응답: {}", aiResponse);
+
+        saveQuizDataFromResponse(aiResponse, report);
+
+    }
+
+    private List<BufferedImage> convertPdfToImages(MultipartFile file) throws IOException {
+        List<BufferedImage> images = new ArrayList<>();
+
+        try (PDDocument document = PDDocument.load(file.getInputStream())) {
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+
+            for (int page = 0; page < document.getNumberOfPages(); page++) {
+                BufferedImage image = pdfRenderer.renderImageWithDPI(page, 300, ImageType.RGB);
+                images.add(image);
+            }
+        }
+        return images;
+    }
+
+    private void saveQuizDataFromResponse(String aiResponse, Report report) {
+        try {
+            if (aiResponse.contains("{")) {
+                aiResponse = aiResponse.substring(aiResponse.indexOf("{"));
+            }
+            if (aiResponse.contains("}")) {
+                aiResponse = aiResponse.substring(0, aiResponse.lastIndexOf("}") + 1);
+            }
+            log.info("AI 응답: {}", aiResponse);
+
+            JsonNode rootNode = objectMapper.readTree(aiResponse);
+            JsonNode quizzesNode = rootNode.get("quizzes");
+
+            if (quizzesNode == null || !quizzesNode.isArray()) {
+                log.error("AI 응답에서 'quizzes' 키가 없거나 배열 형식이 아닙니다.");
+                throw new RuntimeException("AI 응답 데이터 처리 중 오류 발생");
+            }
+
+            List<LocalDateTime> reviewDates = List.of(
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(3),
+                LocalDateTime.now().plusDays(7),
+                LocalDateTime.now().plusDays(14)
+            );
+
+            int index = 0;
+
+            for (JsonNode quizNode : quizzesNode) {
+                String title = quizNode.get("title").asText();
+//                String category = quizNode.has("category") ? quizNode.get("category").asText() : "기타";
+                JsonNode questionsNode = quizNode.get("questions");
+
+                if (questionsNode == null || !questionsNode.isArray()) {
+                    log.error("퀴즈 '{}'의 'questions' 키가 없거나 배열 형식이 아닙니다.", title);
+                    throw new RuntimeException("AI 응답 데이터 처리 중 오류 발생");
+                }
+
+                Quiz quiz = Quiz.builder()
+                    .category("직접 지정 or Todo 제목")
+                    .title(title)
+                    .reviewDate(reviewDates.get(index % reviewDates.size()))
+                    .questionCnt(questionsNode.size())
+                    .report(report)
+                    .build();
+                quizRepository.save(quiz);
+
+                index++;
+
+                for (JsonNode questionNode : questionsNode) {
+                    String content = questionNode.get("content").asText();
+                    String correctOption = String.valueOf(questionNode.get("correct").asInt());
+                    int questionNum = questionNode.get("question_id").asInt();
+                    JsonNode optionsNode = questionNode.get("options");
+
+                    if (optionsNode == null || !optionsNode.isArray()) {
+                        log.error("질문 '{}'의 'options' 키가 없거나 배열 형식이 아닙니다.", content);
+                        throw new RuntimeException("AI 응답 데이터 처리 중 오류 발생");
+                    }
+
+                    Question question = Question.builder()
+                        .content(content)
+                        .correct(correctOption)
+                        .questionNum(questionNum)
+                        .quiz(quiz)
+                        .build();
+                    questionRepository.save(question);
+
+                    for (JsonNode optionNode : optionsNode) {
+                        String optionContent = optionNode.get("content").asText();
+
+                        Option option = Option.builder()
+                            .content(optionContent)
+                            .question(question)
+                            .build();
+                        optionRepository.save(option);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("AI 응답 처리 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("AI 응답 데이터 처리 중 오류 발생", e);
+        }
+    }
+
+
+}

--- a/src/main/java/PlanQ/PlanQ/report/ReportController.java
+++ b/src/main/java/PlanQ/PlanQ/report/ReportController.java
@@ -1,8 +1,10 @@
 package PlanQ.PlanQ.report;
 
+import PlanQ.PlanQ.quiz.QuizService;
 import PlanQ.PlanQ.report.dto.request.RequestReportDto;
 import PlanQ.PlanQ.report.dto.response.ResponsePdfDto;
 import io.swagger.v3.oas.annotations.Operation;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -16,17 +18,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReportController {
     private final ReportService reportService;
+    private final QuizService quizService;
 
     @Operation(summary = "리포트 업로드", description = "리포트 업로드")
     @PostMapping("/todo/{todoId}")
     public ResponseEntity<Long> uploadReport(@PathVariable Long todoId,
                                              @RequestPart(value = "file", required = false) MultipartFile file,
-                                             @RequestPart(value = "info") @Validated RequestReportDto requestReportDto){
-        Long response = reportService.createReport(todoId, file, requestReportDto);
-        if(response == null){
+                                             @RequestPart(value = "info") @Validated RequestReportDto requestReportDto) throws IOException {
+        Report report = reportService.createReport(todoId, file, requestReportDto);
+        quizService.generateQuizFromPdf(file, report);
+        if(report == null){
             return ResponseEntity.badRequest().body(0L);
         }
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(report.getId());
     }
 
     @Operation(summary = "리포트 달별로 확인 Month의 값을 0으로 줄시 모든 리포트 반환", description = "리포트 달별 확인")

--- a/src/main/java/PlanQ/PlanQ/report/ReportService.java
+++ b/src/main/java/PlanQ/PlanQ/report/ReportService.java
@@ -34,14 +34,14 @@ public class ReportService {
     }
 
     @Transactional
-    public Long createReport(Long todoId, MultipartFile file, RequestReportDto requestReportDto){
+    public Report createReport(Long todoId, MultipartFile file, RequestReportDto requestReportDto){
         Todo todo = todoService.findById(todoId);
         String s3Url = s3Service.upload(file);
         System.out.println("S3 URL: " + s3Url);
         Report report = requestReportDto.toEntity(s3Url, todo);
         reportRepository.save(report);
         todoService.updateIsClear(todo);
-        return report.getId();
+        return report;
     }
 
     public List<ResponsePdfDto> getPdfOfYearMonth(Long year, Long month){

--- a/src/main/resources/static/application-keys.yml
+++ b/src/main/resources/static/application-keys.yml
@@ -91,3 +91,85 @@ cloud:
       static: us-east-1
     stack:
       auto: false
+
+quiz:
+  generation:
+    prompt: >
+      사진 내용을 기반으로 총 4일치 퀴즈를 생성하세요. 각 퀴즈는 PDF 내용의 길이에 따라 1, 3, 5, 10개의 질문을 포함하며, 모든 질문은 사지선다형(보기 4개)으로 작성됩니다. 정답 번호는 `correct` 필드에 명시해주세요.
+      반드시 JSON 형태로 답해주세요.
+      
+      **요구사항**:
+      1. PDF를 분석하여 4일치 퀴즈를 생성합니다. 각 퀴즈는 고유한 `day` 값과 `title`을 가집니다.
+      2. 각 퀴즈에는 `questionCnt` 필드로 질문 개수를 표시하며, 질문 개수는 PDF 내용 길이에 따라 다릅니다:
+         - 짧은 내용: 질문 1개
+         - 중간 내용: 질문 3개
+         - 긴 내용: 질문 5개
+         - 매우 긴 내용: 질문 10개
+      3. 각 질문은 다음 요소를 포함합니다:
+         - `question_id`: 질문 ID
+         - `content`: 질문 내용
+         - `options`: 보기 4개 (`option_id`와 `content`로 구성)
+         - `correct`: 정답 번호 (1~4)
+
+      **JSON 형식**:
+      {
+        "quizzes": [
+          {
+            "day": 1,
+            "title": "string",  // 퀴즈 제목
+            "questionCnt": 1,  // 퀴즈에 포함된 질문 수
+            "questions": [
+              {
+                "question_id": 1,
+                "content": "string",  // 질문 내용
+                "options": [
+                  { "option_id": 1, "content": "string" },  // 보기 1
+                  { "option_id": 2, "content": "string" },  // 보기 2
+                  { "option_id": 3, "content": "string" },  // 보기 3
+                  { "option_id": 4, "content": "string" }   // 보기 4
+                ],
+                "correct": 1  // 정답 보기 번호
+              }
+            ]
+          }
+        ]
+      }
+
+      **예시**:
+      사진 내용:
+      "조선 시대의 문화유산에 대해 배웠습니다. 경복궁과 창덕궁은 조선을 대표하는 궁궐이며, 세종대왕의 한글 창제는 조선의 중요한 업적입니다."
+
+      응답 예시:
+      {
+        "quizzes": [
+          {
+            "day": 1,
+            "title": "조선 시대의 문화유산",
+            "questionCnt": 2,
+            "questions": [
+              {
+                "question_id": 1,
+                "content": "경복궁과 창덕궁은 어떤 시대의 건축물인가요?",
+                "options": [
+                  { "option_id": 1, "content": "조선 시대" },
+                  { "option_id": 2, "content": "고려 시대" },
+                  { "option_id": 3, "content": "삼국 시대" },
+                  { "option_id": 4, "content": "일제 강점기" }
+                ],
+                "correct": 1
+              },
+              {
+                "question_id": 2,
+                "content": "세종대왕의 업적은 무엇인가요?",
+                "options": [
+                  { "option_id": 1, "content": "훈민정음 창제" },
+                  { "option_id": 2, "content": "경복궁 건립" },
+                  { "option_id": 3, "content": "대마도 정벌" },
+                  { "option_id": 4, "content": "병자호란 승리" }
+                ],
+                "correct": 1
+              }
+            ]
+          }
+        ]
+      }

--- a/src/main/resources/static/application-keys.yml
+++ b/src/main/resources/static/application-keys.yml
@@ -63,6 +63,23 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: org.mariadb.jdbc.Driver
 
+  ai:
+    vertex:
+      ai:
+        gemini:
+          project-id: ${VERTEX_PROJECT_ID}
+          location: asia-northeast3
+          chat:
+            options:
+              model: "vertex-pro-vision"
+              temperature: 0.5
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o
+          temperature: 0.5
+
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
### ⚠️ PR check list ⚠️
```
- commit message가 적절한지 확인해주세요. 
- Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
```

## PR 요약
퀴즈 생성 및 Quiz, Question, Option 데이터 저장
- API 호출 비용을 고려해 Vertex AI 사용을 검토했으나, Vertex AI를 사용하면 팀원들의 로컬 환경 설정 작업이 추가적으로 필요하다는 점을 감안해 OpenAI로 작업했습니다.
- Spring AI의 강점인 LLM 모델 변경의 유연성을 활용해, 추후 Vertex AI로 전환할 예정입니다.
## 확인사항
@ChaGyoungtae 
[[REFACTOR] Entity 수정](https://github.com/Scheduler-prj/back-end/commit/a20c5fa2646919c2d0b05b1569e4f24ece850a80)
[[REFACTOR] DashBoard 관련 레포지토리 및 DTO 수정](https://github.com/Scheduler-prj/back-end/commit/34dc1cb52bb7e26af490bfd4216893ecfd2d9878)

@sdrong 
[[FEAT] AI 퀴즈 생성 및 저장 구현](https://github.com/Scheduler-prj/back-end/commit/504631c2d0bf7759f03c22d1bb744f5ffa3e68db)

@choizeus02 
[[CHORE] AI 서비스 관련 key 설정](https://github.com/Scheduler-prj/back-end/commit/4df9141b6306a40e90a9a1d1b49868e507d4d024)

커밋의 `...` 버튼을 눌러 확인해주세요.
## 변경 사항
pdfbox, spring ai Dependency 추가
